### PR TITLE
Configure build-scan plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+install: true
+script:
+  - ./gradlew build --scan

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,16 @@
 plugins {
+    id 'com.gradle.build-scan' version '1.16'
+    id 'groovy'
     id 'java-gradle-plugin'
     id 'com.gradle.plugin-publish' version '0.10.0'
     id 'org.unbroken-dome.test-sets' version '1.5.1'
     id "com.bmuschko.nexus" version "2.3.1"
 }
-apply plugin: 'groovy'
+
+buildScan {
+    termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
+}
 
 group 'fi.linuxbox.gradle'
 version '0.6-SNAPSHOT'


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.